### PR TITLE
Fix: 다중 프로세스 추적을 위한 PPID 검사 및 bcc 호환성 수정

### DIFF
--- a/projects/kyj/ebpf-model-profiler/requirements.txt
+++ b/projects/kyj/ebpf-model-profiler/requirements.txt
@@ -2,7 +2,7 @@
 # Python dependencies for the profiler
 
 # eBPF framework
-bcc>=0.18.0
+# bcc>=0.18.0
 
 # Metrics export
 prometheus-client>=0.12.0

--- a/projects/kyj/ebpf-model-profiler/src/collector/tracer.py
+++ b/projects/kyj/ebpf-model-profiler/src/collector/tracer.py
@@ -6,6 +6,7 @@ Uses BCC (BPF Compiler Collection) to compile and load eBPF programs into the ke
 
 import os
 from bcc import BPF
+import ctypes as ct
 from pathlib import Path
 from typing import Optional, List, Dict, Callable
 import logging
@@ -103,7 +104,7 @@ class LatencyTracer:
         Set PID filter in eBPF map to only trace specific process.
         """
         pid_filter = self.bpf.get_table("pid_filter")
-        pid_filter[self.bpf.ctype.c_uint(self.pid)] = self.bpf.ctype.c_ubyte(1)
+        pid_filter[ct.c_uint(self.pid)] = ct.c_ubyte(1)
         self.logger.info(f"PID filter set to {self.pid}")
 
     def _attach_syscalls(self):

--- a/projects/kyj/ebpf-model-profiler/src/ebpf/syscall_tracer.c
+++ b/projects/kyj/ebpf-model-profiler/src/ebpf/syscall_tracer.c
@@ -4,7 +4,7 @@
 // It uses kprobe/kretprobe to hook into syscall entry and exit points.
 
 #include <uapi/linux/ptrace.h>
-#include <linux/sched.h>
+#include <linux/sched.h> // <--- PPID를 위해 sched.h 포함
 #include "common.h"
 
 // Hash map to store start timestamps keyed by thread ID
@@ -35,14 +35,23 @@ static inline int should_trace(u32 pid) {
  * This is called when a traced syscall is entered.
  * Records the entry timestamp for latency calculation.
  */
-int trace_syscall_enter(struct pt_regs *ctx) {
+static inline int trace_syscall_enter(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    u32 pid = pid_tgid >> 32;
+    u32 pid = pid_tgid >> 32;   // current PID ..
     u32 tid = pid_tgid;
 
     // Check if we should trace this PID
     if (!should_trace(pid)) {
-        return 0;
+        // If current PID isn't traced, check if its Parent PID (PPID) is.
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+
+        // Safely read the parent's PID (tgid)
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     // Record start time for this thread
@@ -66,8 +75,15 @@ int trace_openat_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -104,8 +120,15 @@ int trace_read_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -142,8 +165,15 @@ int trace_write_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -180,8 +210,15 @@ int trace_nanosleep_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -218,8 +255,15 @@ int trace_sendto_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -256,8 +300,15 @@ int trace_recvfrom_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -294,8 +345,15 @@ int trace_sendmsg_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -332,8 +390,15 @@ int trace_recvmsg_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -370,8 +435,15 @@ int trace_fsync_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
+    // Check if we should trace this PID or its Parent
     if (!should_trace(pid)) {
-        return 0;
+        struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+        u32 ppid = 0;
+        bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);
+
+        if (!should_trace(ppid)) {
+            return 0; // Neither PID nor PPID is traced, skip.
+        }
     }
 
     u64 *start_ts = start_times.lookup(&pid_tgid);
@@ -396,5 +468,6 @@ int trace_fsync_exit(struct pt_regs *ctx) {
     events.perf_submit(ctx, &event, sizeof(event));
     start_times.delete(&pid_tgid);
 
-    return 0;
+ 
+   return 0;
 }


### PR DESCRIPTION
- ERROR: No matching distribution found for bcc
원인: bcc는 pip가 아닌 apt로 설치해야 하는 시스템 라이브러리이다.
해결: sudo apt-get install bpfcc-tools ...로 설치 후, requirements.txt에서 bcc 라인을 주석 처리했다.

 - error: cannot call non-static helper function
원인: 프로파일러의 C 코드가 최신 리눅스 커널의 엄격한 규칙과 호환되지 않았다.
해결: src/ebpf/syscall_tracer.c 파일의 trace_syscall_enter 함수 정의부 앞에 static inline을 추가했다.

- AttributeError: 'BPF' object has no attribute 'ctype'
원인: 프로파일러의 Python 코드가 오래된 bcc API를 사용했다.
해결: src/collector/tracer.py 파일의 .ctype을 Python 내장 ctypes 모듈을 사용하도록 수정했다. (import ctypes as ct 추가, ct.c_uint(...)로 변경)

- 다중 프로세스 구조에서도 적용할 수 있게... (자식 프로세스들까지 모두 추적시키기)
 trace_syscall_enter 함수와 9개의 모든 _exit 함수의 should_trace(pid) 검사 로직을 다음과 같이 변경했다.

```c
// (수정 전)
// if (!should_trace(pid)) {
//     return 0;
// }

// (수정 후)
// "현재 PID"가 추적 대상이 아니면, "부모 PID"도 검사!

if (!should_trace(pid)) {
    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
    u32 ppid = 0;
    bpf_probe_read_kernel(&ppid, sizeof(ppid), &task->real_parent->tgid);

    if (!should_trace(ppid)) {
        return 0; // 둘 다 아니면 무시
    }
}
```

---
실습에 대한 진행을 담은 글
https://velog.io/@weeeeestern/%EC%BB%A4%EB%84%90-%EB%A0%88%EB%B2%A8%EC%97%90%EC%84%9C-fastapi-%EB%AA%A8%EB%8D%B8-%EC%A7%80%EC%97%B0-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81-%ED%95%98%EA%B8%B0
+) export 명령어는 (제가 잘못 실습을 진행했을 수도 있을 것 같은데....) 작동하지 않았습니다.. 
그래서 그냥 start 후 Ctrl+C 로 나오는 결과창을 보고 모니터링 결과를 확인할 수 있었습니다.
<img width="982" height="391" alt="image" src="https://github.com/user-attachments/assets/2e8043e1-e8d9-4e0d-b67c-3716ab389b42" />
